### PR TITLE
fix for debian 10

### DIFF
--- a/xlxd-debian-installer.sh
+++ b/xlxd-debian-installer.sh
@@ -22,7 +22,20 @@ XLXDREPO=https://github.com/LX3JL/xlxd.git
 DMRIDURL=http://xlxapi.rlx.lu/api/exportdmr.php
 WEBDIR=/var/www/xlxd
 XLXINSTDIR=/root/reflector-install-files/xlxd
-DEP="git build-essential apache2 php libapache2-mod-php php7.0-mbstring"
+
+# determine whick packages are needed based on Debian version
+DEBVER=`/bin/sed -r 's/([0-9]+)\..*$/\1/' /etc/debian_version`
+case $DEBVER in
+  7|8|9)
+    DEP="git build-essential apache2 php libapache2-mod-php php7.0-mbstring"
+    AMOD="php7.0"
+    ;;
+  *)
+    DEP="git build-essential apache2 php7.3 libapache2-mod-php7.3 php7.3-mbstring"
+    AMOD="php7.3"
+    ;;
+esac
+
 clear
 echo ""
 echo "XLX uses 3 digit numbers for its reflectors. For example: 032, 999, 099."
@@ -46,7 +59,7 @@ mkdir -p $XLXINSTDIR
 mkdir -p $WEBDIR
 apt-get update
 apt-get -y install $DEP
-a2enmod php7.0
+a2enmod $AMOD
 echo "------------------------------------------------------------------------------"
 if [ -e $XLXINSTDIR/xlxd/src/xlxd ]
 then


### PR DESCRIPTION
add logic to use PHP 7.0 or PHP 7.3 as appropriate with future expandability